### PR TITLE
Add distinct deploy and update steps

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,7 +35,15 @@ workflows:
             - lint
 
       - orb-tools/publish:
-          name: publish
+          name: publish-test-channel
+          attach-workspace: true
+          checkout: false
+          orb-ref: "borb/zappa@dev:test-channel"
+          requires:
+            - pack
+
+      - orb-tools/publish:
+          name: publish-branch-channel
           attach-workspace: true
           checkout: false
           orb-ref: "borb/zappa@dev:${CIRCLE_BRANCH}"
@@ -45,4 +53,4 @@ workflows:
       - run_tests:
           name: "Compile test manifests and run tests"
           requires:
-            - publish
+            - publish-test-channel

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,10 +14,13 @@ jobs:
       - run: pipenv install --dev
       - run: circleci config process test/manifest/simple.yml > simple.yml
       - run: circleci config process test/manifest/executor.yml > executor.yml
+      - run: circleci config process test/manifest/update_only.yml > update_only.yml
       - store_artifacts:
           path: simple.yml
       - store_artifacts:
           path: executor.yml
+      - store_artifacts:
+          path: update_only.yml
       - run: pipenv run python -m unittest test
 
 workflows:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - New commands: `zappa/deploy` and `zappa/update`
 - New parameter for the `zappa-deploy` job: `update_only`
 
+### Changed
+- Steps no longer generate run commands with trailing newlines
+
 ## [0.0.3] - 2019-02-05
 ### Added
 - New parameter for the `zappa-deploy` job: `python_version`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- New commands: `zappa/deploy` and `zappa/update`
 
 ## [0.0.3] - 2019-02-05
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Added
 - New commands: `zappa/deploy` and `zappa/update`
+- New parameter for the `zappa-deploy` job: `update_only`
 
 ## [0.0.3] - 2019-02-05
 ### Added

--- a/src/commands/deploy-or-update.yml
+++ b/src/commands/deploy-or-update.yml
@@ -11,7 +11,7 @@ parameters:
 steps:
   - run:
       name: Deploying to << parameters.stage >>
-      command: |
+      command: |-
         set +e
         STATUS=$(pipenv run zappa status << parameters.stage >> -j 2>&1)
         set -e

--- a/src/commands/deploy.yml
+++ b/src/commands/deploy.yml
@@ -1,0 +1,15 @@
+description: >
+  Deploy a new Zappa stage.
+
+parameters:
+  stage:
+    type: string
+    default: "dev"
+    description: >
+      The name of the Zappa stage to deploy to.
+
+steps:
+  - run:
+      name: Deploying to << parameters.stage >>
+      command: |
+         pipenv run zappa deploy << parameters.stage >>

--- a/src/commands/deploy.yml
+++ b/src/commands/deploy.yml
@@ -11,5 +11,5 @@ parameters:
 steps:
   - run:
       name: Deploying to << parameters.stage >>
-      command: |
+      command: |-
          pipenv run zappa deploy << parameters.stage >>

--- a/src/commands/update.yml
+++ b/src/commands/update.yml
@@ -11,5 +11,5 @@ parameters:
 steps:
   - run:
       name: Deploying update to << parameters.stage >>
-      command: |
+      command: |-
         pipenv run zappa update << parameters.stage >>

--- a/src/commands/update.yml
+++ b/src/commands/update.yml
@@ -1,0 +1,15 @@
+description: >
+  Update an existing Zappa stage.
+
+parameters:
+  stage:
+    type: string
+    default: "dev"
+    description: >
+      The name of the Zappa stage to update.
+
+steps:
+  - run:
+      name: Deploying update to << parameters.stage >>
+      command: |
+        pipenv run zappa update << parameters.stage >>

--- a/src/jobs/zappa-deploy.yml
+++ b/src/jobs/zappa-deploy.yml
@@ -12,6 +12,11 @@ parameters:
     default: "2.7"
     description: >
       The version of Python to deploy with.
+  update_only:
+    type: boolean
+    default: false
+    description: >
+      Whether to disallow a new stage being deployed.
 
 executor:
   name: python
@@ -20,5 +25,13 @@ executor:
 steps:
   - checkout
   - run: pipenv install
-  - deploy-or-update:
-      stage: << parameters.stage >>
+  - unless:
+      condition: << parameters.update_only >>
+      steps:
+        - deploy-or-update:
+            stage: << parameters.stage >>
+  - when:
+      condition: << parameters.update_only >>
+      steps:
+        - update:
+            stage: << parameters.stage >>

--- a/test/__init__.py
+++ b/test/__init__.py
@@ -1,2 +1,3 @@
 from .test_executor import TestExecutor
 from .test_simple import TestSimple
+from .test_update_only import TestUpdateOnly

--- a/test/manifest/executor.yml
+++ b/test/manifest/executor.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  zappa: "borb/zappa@volatile"
+  zappa: "borb/zappa@dev:test-channel"
 
 workflows:
   deploy-demo:

--- a/test/manifest/simple.yml
+++ b/test/manifest/simple.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  zappa: "borb/zappa@volatile"
+  zappa: "borb/zappa@dev:test-channel"
 
 workflows:
   deploy-demo:

--- a/test/manifest/update_only.yml
+++ b/test/manifest/update_only.yml
@@ -1,0 +1,21 @@
+version: 2.1
+
+orbs:
+  zappa: "borb/zappa@volatile"
+
+workflows:
+  test-workflow:
+    jobs:
+      - zappa/zappa-deploy:
+          name: "zappa-deploy-update_only-true"
+          stage: borb
+          update_only: true
+
+      - zappa/zappa-deploy:
+          name: "zappa-deploy-update_only-false"
+          stage: borb
+          update_only: false
+
+      - zappa/zappa-deploy:
+          name: "zappa-deploy-update_only-absent"
+          stage: borb

--- a/test/manifest/update_only.yml
+++ b/test/manifest/update_only.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  zappa: "borb/zappa@volatile"
+  zappa: "borb/zappa@dev:test-channel"
 
 workflows:
   test-workflow:

--- a/test/test_simple.py
+++ b/test/test_simple.py
@@ -52,6 +52,6 @@ class TestSimple(unittest.TestCase):
             'elif [[ "$STATUS" == *"have you deployed yet?" ]];\n'
             'then pipenv run zappa deploy borb;\n'
             'else echo "$STATUS\\nUnknown error!" && exit 1\n'
-            'fi\n')
+            'fi')
 
         self.assertTrue(expected_step == actual_step)

--- a/test/test_simple.py
+++ b/test/test_simple.py
@@ -1,4 +1,3 @@
-from pprint import pprint as pp
 import os
 import unittest
 
@@ -10,7 +9,6 @@ class TestSimple(unittest.TestCase):
     def setUp(self):
         with open("simple.yml") as f:
             self.config = yaml.load(f)
-            pp(self.config)
 
     def test_high_level_keys_are_correct(self):
        actual_keys = self.config.keys()

--- a/test/test_update_only.py
+++ b/test/test_update_only.py
@@ -1,0 +1,59 @@
+import os
+from pprint import pprint as pp
+import unittest
+
+import yaml
+
+
+class TestUpdateOnly(unittest.TestCase):
+
+    def setUp(self):
+        with open("update_only.yml") as f:
+            self.config = yaml.load(f)
+            pp(self.config)
+
+    def test_high_level_keys_are_correct(self):
+       actual_keys = self.config.keys()
+       expected_keys = ['jobs', 'version', 'workflows']
+
+       self.assertTrue(set(expected_keys) == set(actual_keys))
+
+    def test_job_is_present(self):
+        actual_jobs = self.config['jobs'].keys()
+        expected_jobs = ['zappa/zappa-deploy']
+
+        self.assertTrue(set(expected_jobs) == set(actual_jobs))
+
+    def test_job_uses_py27_image(self):
+        actual_images = [
+            docker_config['image']
+            for docker_config in self.config['jobs']['zappa/zappa-deploy']['docker']]
+        expected_images = ['circleci/python:2.7']
+
+        self.assertTrue(set(expected_images) == set(actual_images))
+
+    def test_job_contains_three_steps(self):
+        actual_steps = self.config['jobs']['zappa/zappa-deploy']['steps']
+
+        self.assertTrue(len(actual_steps) == 3)
+
+    def test_job_step_one_checks_out(self):
+        actual_step = self.config['jobs']['zappa/zappa-deploy']['steps'][0]
+        expected_step = 'checkout'
+
+        self.assertTrue(expected_step == actual_step)
+
+    def test_job_step_three_performs_create_or_update(self):
+        actual_step = self.config['jobs']['zappa/zappa-deploy']['steps'][2]['run']['command']
+        expected_step = (
+            'set +e\n'
+            'STATUS=$(pipenv run zappa status borb -j 2>&1)\n'
+            'set -e\n'
+            'if [[ $(echo $STATUS | jq . 2>/dev/null) ]];\n'
+            'then pipenv run zappa update borb;\n'
+            'elif [[ "$STATUS" == *"have you deployed yet?" ]];\n'
+            'then pipenv run zappa deploy borb;\n'
+            'else echo "$STATUS\\nUnknown error!" && exit 1\n'
+            'fi\n')
+
+        self.assertTrue(expected_step == actual_step)

--- a/test/test_update_only.py
+++ b/test/test_update_only.py
@@ -1,5 +1,4 @@
 import os
-from pprint import pprint as pp
 import unittest
 
 import yaml
@@ -29,8 +28,6 @@ class TestUpdateOnly(unittest.TestCase):
     def test_update_only_true_performs_update_only(self):
         job = self.config['jobs']['zappa-deploy-update_only-true']
         actual_step = job['steps'][2]['run']['command']
-
-        pp(actual_step)
 
         expected_step = 'pipenv run zappa update borb'
 

--- a/test/test_update_only.py
+++ b/test/test_update_only.py
@@ -1,5 +1,4 @@
 import os
-from pprint import pprint as pp
 import unittest
 
 import yaml
@@ -10,7 +9,6 @@ class TestUpdateOnly(unittest.TestCase):
     def setUp(self):
         with open("update_only.yml") as f:
             self.config = yaml.load(f)
-            pp(self.config)
 
     def test_high_level_keys_are_correct(self):
        actual_keys = self.config.keys()

--- a/test/test_update_only.py
+++ b/test/test_update_only.py
@@ -32,7 +32,7 @@ class TestUpdateOnly(unittest.TestCase):
 
         pp(actual_step)
 
-        expected_step = 'pipenv run zappa deploy borb'
+        expected_step = 'pipenv run zappa update borb'
 
         self.assertTrue(expected_step == actual_step)
 

--- a/test/test_update_only.py
+++ b/test/test_update_only.py
@@ -1,4 +1,5 @@
 import os
+from pprint import pprint as pp
 import unittest
 
 import yaml
@@ -28,6 +29,9 @@ class TestUpdateOnly(unittest.TestCase):
     def test_update_only_true_performs_update_only(self):
         job = self.config['jobs']['zappa-deploy-update_only-true']
         actual_step = job['steps'][2]['run']['command']
+
+        pp(actual_step)
+
         expected_step = 'pipenv run zappa deploy borb'
 
         self.assertTrue(expected_step == actual_step)
@@ -44,7 +48,7 @@ class TestUpdateOnly(unittest.TestCase):
             'elif [[ "$STATUS" == *"have you deployed yet?" ]];\n'
             'then pipenv run zappa deploy borb;\n'
             'else echo "$STATUS\\nUnknown error!" && exit 1\n'
-            'fi\n')
+            'fi')
 
         self.assertTrue(expected_step == actual_step)
 
@@ -60,6 +64,6 @@ class TestUpdateOnly(unittest.TestCase):
             'elif [[ "$STATUS" == *"have you deployed yet?" ]];\n'
             'then pipenv run zappa deploy borb;\n'
             'else echo "$STATUS\\nUnknown error!" && exit 1\n'
-            'fi\n')
+            'fi')
 
         self.assertTrue(expected_step == actual_step)


### PR DESCRIPTION
This PR adds new step commands: `zappa/deploy` and `zappa/update`, along with an `update_only` parameter to the `zappa/deploy-or-update` command.